### PR TITLE
Show warning on empty body from Buienradar

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if len(info) == 0 {
+		fmt.Fprintln(os.Stderr, "Warning: Empty body received from Buienradar")
+	}
+
 	for _, point := range info {
 		fmt.Printf(
 			"%02d:%02d: %.1fmm/u\n",


### PR DESCRIPTION
This shows a warning line on stderr if no data was received from upstream.
Would be useful, I think, to diagnose that a problem is not with this tool but
with upstream.